### PR TITLE
#165305224 Implement social login

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,10 +9,6 @@
     "sourceType": "module",
     "allowImportExportEverywhere": true
   },
-  "parserOptions": {
-    "sourceType": "module",
-    "allowImportExportEverywhere": true
-  },
   "extends": "airbnb",
   "plugins": ["babel", "import", "jsx-a11y", "react", "prettier"],
   "rules": {
@@ -30,6 +26,15 @@
       {
         "extensions": [".js", ".jsx"]
       }
-    ]
+    ],
+    "react/button-has-type": [
+      0,
+      {
+        "button": false,
+        "submit": false,
+        "reset": false
+      }
+    ],
+    "arrow-parens": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start:dev": "webpack-dev-server --mode development --open --hot",
+    "start:dev": "webpack-dev-server --mode development --open --https --hot",
     "build": "webpack --mode production",
     "serve": "node server.js",
     "test": "jest",
@@ -48,6 +48,9 @@
     "react-bootstrap": "^1.0.0-beta.9",
     "react-dom": "^16.8.6",
     "react-inline-editable-field": "^1.0.6",
+    "react-facebook-login": "^4.1.1",
+    "react-google-login": "^5.0.4",
+    "react-icons": "^3.7.0",
     "react-redux": "^7.0.3",
     "react-router-dom": "^5.0.0",
     "react-toastify": "^5.2.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -6,4 +6,5 @@ module.exports = {
   jsxBracketSameLine: false,
   tabWidth: 2,
   semi: true,
+  // arrowParens: 'always',
 };

--- a/src/assets/styles/social.scss
+++ b/src/assets/styles/social.scss
@@ -1,0 +1,62 @@
+/* Shared */
+.loginBtn {
+  box-sizing: border-box;
+  position: relative;
+  margin: 0.2em;
+  padding: 0 15px 0 46px;
+  border: none;
+  text-align: left;
+  line-height: 34px;
+  white-space: nowrap;
+  border-radius: 0.2em;
+  font-size: 16px;
+  color: #fff;
+  width: -webkit-fill-available;
+  text-align: -webkit-center;
+}
+.loginBtn:before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 34px;
+  height: 100%;
+}
+.loginBtn:focus {
+  outline: none;
+}
+.loginBtn:active {
+  box-shadow: inset 0 0 0 32px rgba(0, 0, 0, 0.1);
+}
+
+/* Facebook */
+.loginBtn--facebook {
+  background-color: #4c69ba;
+  background-image: linear-gradient(#4c69ba, #3b55a0);
+  text-shadow: 0 -1px 0 #354c8c;
+}
+.loginBtn--facebook:before {
+  border-right: #364e92 1px solid;
+  background: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/14082/icon_facebook.png') 6px 6px
+    no-repeat;
+}
+.loginBtn--facebook:hover,
+.loginBtn--facebook:focus {
+  background-color: #5b7bd5;
+  background-image: linear-gradient(#5b7bd5, #4864b1);
+}
+
+/* Google */
+.loginBtn--google {
+  background: #dd4b39;
+}
+.loginBtn--google:before {
+  border-right: #bb3f30 1px solid;
+  background: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/14082/icon_google.png') 6px 6px
+    no-repeat;
+}
+.loginBtn--google:hover,
+.loginBtn--google:focus {
+  background: #e74b37;
+}

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Form, Spinner } from 'react-bootstrap';
+import SocialLogin from './Social';
 import '../../assets/styles/login.scss';
 
 class LoginForm extends Component {
@@ -74,8 +75,8 @@ class LoginForm extends Component {
               <p className="separator-text">OR</p>
               <div className="separator-line" />
             </div>
-            <div className="social">
-              <p>Social login icons here</p>
+            <div className="rounded-social-buttons">
+              <SocialLogin />
             </div>
             <div className="login">
               <p>No account?</p>

--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -2,11 +2,13 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Form, Button, Spinner } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import SocialLogin from './Social';
 import '../../assets/styles/signup.scss';
+import '../../assets/styles/social.scss';
 
 class SignupForm extends Component {
   render() {
-    const { onSubmit, onChange, error, handleConfirmPassword, isLoading } = this.props;
+    const { onSubmit, onChange, error, handleConfirmPassword, isLoading, social } = this.props;
     return (
       <div className="signup-page">
         <h1>Authors Haven</h1>
@@ -89,6 +91,9 @@ class SignupForm extends Component {
               <div className="separator-line" />
               <p className="separator-text">OR</p>
               <div className="separator-line" />
+            </div>
+            <div className="rounded-social-buttons">
+              <SocialLogin />
             </div>
             <div className="login">
               <p>Already have an account?</p>

--- a/src/components/auth/Social.js
+++ b/src/components/auth/Social.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import FacebookLogin from 'react-facebook-login/dist/facebook-login-render-props';
+import { GoogleLogin } from 'react-google-login';
+import { UserSocialLogin } from '../../redux/actions/loginActions';
+import { errorToast } from '../../helpers';
+import '../../assets/styles/social.scss';
+
+class SocialLogin extends Component {
+  state = {
+    isClicked: false,
+  };
+
+  /*
+   * componentClicked:
+   * changes state to avoid double button click
+   */
+  componentClicked = () => {
+    this.setState({
+      isClicked: true,
+    });
+  };
+
+  /*
+   * responseFacebook:
+   * gets response from Facebook and calls login reducer
+   */
+  responseFacebook = response => {
+    this.setState({
+      isClicked: true,
+    });
+    const { UserSocialLogin, history } = this.props;
+    UserSocialLogin({ provider: 'facebook', access_token: response.accessToken }, history);
+  };
+
+  /*
+   * googleResponse:
+   * gets response from Google and calls login reducer
+   */
+  googleResponse = response => {
+    this.setState({
+      isClicked: true,
+    });
+    const { UserSocialLogin, history } = this.props;
+    UserSocialLogin({ provider: 'google-oauth2', access_token: response.accessToken }, history);
+  };
+
+  /*
+   * onFailure:
+   * Displays error message in case of failure
+   */
+  onFailure = error => {
+    errorToast('Oops! something went wrong, please try again');
+  };
+
+  render() {
+    return (
+      <div data-set="SocialLoginDiv" className="sld">
+        <FacebookLogin
+          appId="409869986516596"
+          autoLoad={false}
+          fields="name,email,picture"
+          callback={this.responseFacebook}
+          onClick={this.componentClicked}
+          isDisabled={this.state.isClicked}
+          render={renderProps => (
+            <button
+              className="loginBtn loginBtn--facebook"
+              id="facebookLogin"
+              onClick={renderProps.onClick}
+            >
+              Login with Facebook
+            </button>
+          )}
+        />
+
+        <GoogleLogin
+          clientId="857285911538-6jchs8qlak94ek13roke22h2vncbvn5a.apps.googleusercontent.com"
+          render={renderProps => (
+            <button
+              className="loginBtn loginBtn--google"
+              id="googleLogin"
+              onClick={renderProps.onClick}
+              disabled={renderProps.disabled}
+            >
+              Login with Google
+            </button>
+          )}
+          onSuccess={this.googleResponse}
+          onFailure={this.onFailure}
+          disabled={this.state.isClicked}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  myState: state,
+});
+
+const mapDispatchToProps = () => ({
+  UserSocialLogin,
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps(),
+)(withRouter(SocialLogin));

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link
       rel="stylesheet"
@@ -13,7 +16,13 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
     />
     <title>Author's Haven</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
+    <script type="text/javascript">
+      /* this is dummy */
+    </script>
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"
+    />
   </head>
 
   <body>

--- a/src/redux/actions/SignUpAction.js
+++ b/src/redux/actions/SignUpAction.js
@@ -34,3 +34,8 @@ export const verificationFailure = error => ({
   type: `${SIGNUP_USER}_SEND_VERIFICATION_FAILURE`,
   error,
 });
+
+export const socialAction = data => ({
+  type: `${SIGNUP_USER}_SOCIAL`,
+  data,
+});

--- a/src/redux/actions/loginActions.js
+++ b/src/redux/actions/loginActions.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
-import { LOGIN_USER } from '../constants';
+import { LOGIN_USER, SIGNUP_USER } from '../constants';
 import { successToast, errorToast } from '../../helpers';
 import { BASE_URL } from '../constants/index';
+import { socialAction } from './SignUpAction';
 
 /*
  *Defines the loginUser actions and dispatches the right
@@ -25,6 +26,28 @@ export const loginUser = (data, history) => dispatch => {
 };
 
 /*
+ *Defines the actions for social login and dispatches the right
+ *action for either success >>loginSuccessSocial() or
+ *failure >>loginfailure() or
+ */
+export const UserSocialLogin = (data, history) => dispatch => {
+  dispatch({ type: LOGIN_USER });
+  dispatch({ type: SIGNUP_USER });
+  axios
+    .post(`${BASE_URL}/users/social/login/`, data)
+    .then(response => {
+      dispatch(loginSuccessSocial(response.data));
+      dispatch(socialAction(response.data));
+      successToast(`Welcome ${response.data.username}`);
+      history.push('/');
+    })
+    .catch(err => {
+      dispatch(loginFailure(err));
+      errorToast('Oops! something went wrong, please try again');
+      dispatch(socialAction(err));
+    });
+};
+/*
  *Defines the logout actions and dispatches the
  *logout user action
  */
@@ -37,6 +60,14 @@ export const logoutUser = () => dispatch => {
  */
 export const loginSuccess = response => ({
   type: `${LOGIN_USER}_SUCCESS`,
+  response,
+});
+
+/*
+ *Defines the action types for successful social login
+ */
+export const loginSuccessSocial = response => ({
+  type: `${LOGIN_USER}_SUCCESS_SOCIAL`,
   response,
 });
 

--- a/src/redux/reducers/SignUpReducer.js
+++ b/src/redux/reducers/SignUpReducer.js
@@ -31,6 +31,12 @@ export default (state = initialState, action) => {
         isLoading: false,
         error: action.error.response.data,
       };
+    case `${SIGNUP_USER}_SOCIAL`:
+      return {
+        ...state,
+        isLoading: false,
+      };
+
     default:
       return { ...state };
   }

--- a/src/redux/reducers/loginReducer.js
+++ b/src/redux/reducers/loginReducer.js
@@ -4,7 +4,7 @@ const initialState = {
   isAuthenticated: false,
   data: {},
   error: {},
-  isLoading: false,
+  isLoading: false
 };
 
 /*
@@ -16,10 +16,10 @@ const LoginReducer = (state = initialState, action) => {
     case `${LOGIN_USER}`:
       return {
         ...state,
-        isLoading: true,
+        isLoading: true
       };
 
-    case `${LOGIN_USER}_SUCCESS`:
+    case `${LOGIN_USER}_SUCCESS`: {
       const token = action.response.user.token;
       const user = action.response.user;
       localStorage.setItem('token', `Bearer ${token}`);
@@ -29,8 +29,24 @@ const LoginReducer = (state = initialState, action) => {
         ...state,
         isAuthenticated: true,
         isLoading: false,
-        data: action.response,
+        data: action.response
       };
+    }
+
+    case `${LOGIN_USER}_SUCCESS_SOCIAL`: {
+      const token = action.response.token;
+      const userObj = action.response;
+      const user = JSON.stringify(userObj);
+      localStorage.setItem('token', `Bearer ${token}`);
+      localStorage.setItem('user', user);
+
+      return {
+        ...state,
+        isAuthenticated: true,
+        isLoading: false,
+        data: action.response
+      };
+    }
 
     case `${LOGIN_USER}_FAILURE`:
       return {
@@ -38,12 +54,12 @@ const LoginReducer = (state = initialState, action) => {
         isAuthenticated: false,
         isLoading: false,
         error: action.error.response,
-        isError: true,
+        isError: true
       };
     case `${LOGIN_USER}_LOGOUT`:
       return {
         ...state,
-        isAuthenticated: false,
+        isAuthenticated: false
       };
 
     default:

--- a/src/views/SignUpView.js
+++ b/src/views/SignUpView.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { signUpUser } from '../redux/actions/SignUpAction';
 import SignupForm from '../components/auth/Signup';
+import { UserSocialLogin } from '../redux/actions/loginActions';
+import SocialLogin from '../components/auth/Social';
 
 /*
  * SignUpView Component

--- a/tests/Login.test.jsx
+++ b/tests/Login.test.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import moxios from 'moxios';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { mount, shallow } from 'enzyme';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import store from '../src/redux/store/';
+import store from '../src/redux/store';
 import LoginReducer from '../src/redux/reducers/loginReducer';
-import { loginSuccess, loginFailure, logout } from '../src/redux/actions/loginActions';
+import {
+  loginSuccess,
+  loginFailure,
+  logout,
+  loginSuccessSocial,
+} from '../src/redux/actions/loginActions';
 import LoginView from '../src/views/LoginView';
+import { socialAction } from '../src/redux/actions/SignUpAction';
 
 /*
  *This function mounts the
@@ -23,6 +31,10 @@ const setUp = (props = {}) => {
   return component;
 };
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const store1 = mockStore();
+
 /*
  *This function finds a component
  *by its data-set attribute
@@ -33,14 +45,20 @@ const findByAttribute = (component, attr) => {
 };
 
 describe('Unit tests for LoginView component', () => {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  document.getElementsByTagName('head')[0].appendChild(script);
+
   let component;
   beforeEach(() => {
     component = setUp();
   });
+
   it('Should render the loginTestDiv', () => {
     const wrapper = findByAttribute(component, 'loginTestDiv');
     expect(wrapper.exists()).toBe(true);
   });
+
   it('Should render the formTestDiv', () => {
     const wrapper = findByAttribute(component, 'formTestDiv');
     expect(wrapper.exists()).toBe(true);
@@ -85,6 +103,7 @@ describe('tests login reducer', () => {
   beforeEach(() => {
     moxios.install();
   });
+
   afterEach(() => {
     moxios.uninstall();
   });
@@ -102,6 +121,30 @@ describe('tests login reducer', () => {
     };
     await store.dispatch(loginSuccess(response));
     expect(store.getState().LoginReducer.isAuthenticated).toEqual(true);
+    done();
+  });
+
+  it('Tests for success social login action dispatch', async done => {
+    moxios.stubRequest('/social/login');
+    const res = {
+      email: 'kathiekim95@gmail.com',
+      username: 'kathiekim',
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJ1c2VybmFtZSI6ImthdGhpZWtpbTk1QGdtYWlsLmNvbSIsImV4cCI6MTU1OTg2MDM1NywiZW1haWwiOiJrYXRoaWVraW05NUBnbWFpbC5jb20ifQ.taJlapQocvE86WnZNyJhTKwgkzN_ldl4dgM05MWPkkw',
+    };
+    await store.dispatch(loginSuccessSocial(res));
+    await store.dispatch(socialAction(res));
+    expect(store.getState().LoginReducer.isAuthenticated).toEqual(true);
+    done();
+  });
+
+  it('Tests for failure social login action dispatch', async done => {
+    moxios.stubRequest('/social/login', {
+      email: 'oops!, something went wrong',
+    });
+    await store1.dispatch(loginFailure({}));
+    await store1.dispatch(socialAction({}));
+    expect(store1.getActions()[0].type).toEqual('LOGIN_USER_FAILURE');
     done();
   });
 
@@ -146,6 +189,7 @@ describe('changes state', () => {
   );
   newWrapper.setState({ email: 'test@test.com', password: 'TechAt254' });
   newWrapper.update();
+
   it('should update the state', () => {
     expect(newWrapper.state()).toEqual(expectedState);
   });

--- a/tests/LoginActions.test.jsx
+++ b/tests/LoginActions.test.jsx
@@ -1,8 +1,15 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import moxios from 'moxios';
-import { CONSTANTS } from '../src/redux/constants';
-import { loginUser, loginSuccess, loginFailure } from '../src/redux/actions/loginActions';
+import { LOGIN_USER, BASE_URL } from '../src/redux/constants';
+import {
+  loginUser,
+  loginSuccess,
+  loginFailure,
+  loginSuccessSocial,
+  UserSocialLogin,
+} from '../src/redux/actions/loginActions';
+import { socialAction } from '../src/redux/actions/SignUpAction';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -39,5 +46,84 @@ describe('Tests login actions', () => {
     await store.dispatch(loginSuccess({}));
     expect(store.getActions()[0].type).toEqual('LOGIN_USER_SUCCESS');
     done();
+  });
+
+  it('dispatches a successful social login action', async done => {
+    const res = {
+      email: 'kathiekim95@gmail.com',
+      username: 'kathiekim',
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJ1c2VybmFtZSI6ImthdGhpZWtpbTk1QGdtYWlsLmNvbSIsImV4cCI6MTU1OTg2MDM1NywiZW1haWwiOiJrYXRoaWVraW05NUBnbWFpbC5jb20ifQ.taJlapQocvE86WnZNyJhTKwgkzN_ldl4dgM05MWPkkw',
+    };
+
+    moxios.stubRequest('/users/social/login/', {
+      status: 200,
+      response: {
+        res,
+      },
+    });
+    await store.dispatch(loginSuccessSocial({}));
+    const type = store.getActions()[0].type;
+    expect(type).toEqual('LOGIN_USER_SUCCESS_SOCIAL');
+    done();
+  });
+
+  it('dispatches LOGIN_USER_SOCIAL on social login', async done => {
+    const res = {
+      email: 'kathiekim95@gmail.com',
+      username: 'kathiekim',
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJ1c2VybmFtZSI6ImthdGhpZWtpbTk1QGdtYWlsLmNvbSIsImV4cCI6MTU1OTg2MDM1NywiZW1haWwiOiJrYXRoaWVraW05NUBnbWFpbC5jb20ifQ.taJlapQocvE86WnZNyJhTKwgkzN_ldl4dgM05MWPkkw',
+    };
+
+    const expectedAction = loginSuccessSocial(res);
+    moxios.stubRequest(`${BASE_URL}/users/social/login`, { status: 200, response: res });
+    await store.dispatch(loginSuccessSocial(res));
+    expect(store.getActions()).toContainEqual(expectedAction);
+    done();
+  });
+
+  it('dispatches LOGIN_USER_SOCIAL on login', async done => {
+    const res = {
+      user: {
+        email: 'test@gmail.com',
+        username: 'benkim',
+        token:
+          'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJ1c2VybmFtZSI6ImJlbmtpbWVyaWNAZ21haWwuY29tIiwiZXhwIjoxNTU5NjU5NzE0LCJlbWFpbCI6ImJlbmtpbWVyaWNAZ21haWwuY29tIn0.DTW4GmstTCuKMZ7Umock-NARvF346-iQL0uGSgje9UQ',
+      },
+    };
+
+    const expectedAction = loginSuccess(res);
+    moxios.stubRequest(`${BASE_URL}/users/social/login`, { status: 200, response: res });
+    await store.dispatch(loginSuccess(res));
+    expect(store.getActions()).toContainEqual(expectedAction);
+    done();
+  });
+
+  it('returns social login sucess response', () => {
+    const newAction = loginSuccessSocial('success');
+    const expectedAction = {
+      type: `${LOGIN_USER}_SUCCESS_SOCIAL`,
+      response: 'success',
+    };
+    expect(newAction).toEqual(expectedAction);
+  });
+
+  it('returns login sucess response', () => {
+    const newAction = loginSuccess('success');
+    const expectedAction = {
+      type: `${LOGIN_USER}_SUCCESS`,
+      response: 'success',
+    };
+    expect(newAction).toEqual(expectedAction);
+  });
+
+  it('returns login failure response', () => {
+    const newAction = loginFailure('failure');
+    const expectedAction = {
+      type: `${LOGIN_USER}_FAILURE`,
+      error: 'failure',
+    };
+    expect(newAction).toEqual(expectedAction);
   });
 });

--- a/tests/SignUpAction.test.js
+++ b/tests/SignUpAction.test.js
@@ -1,13 +1,14 @@
 import thunk from 'redux-thunk';
+import moxios from 'moxios';
+import configureMockStore from 'redux-mock-store';
+import instance from '../axiosconfig';
+import { SIGNUP_USER, BASE_URL } from '../src/redux/constants';
 import {
   verificationSent,
   verificationFailure,
   signUpUser,
+  socialAction,
 } from '../src/redux/actions/SignUpAction';
-import { SIGNUP_USER, BASE_URL } from '../src/redux/constants';
-import configureMockStore from 'redux-mock-store';
-import moxios from 'moxios';
-import instance from '../axiosconfig';
 
 describe('unit tests for signup actions', () => {
   const middlewares = [thunk];
@@ -74,6 +75,21 @@ describe('unit tests for signup actions', () => {
     const expectedAction = verificationSent(data);
     moxios.stubRequest(`${BASE_URL}/users/`, { status: 201, response: data });
     await store.dispatch(signUpUser(data));
+    expect(store.getActions()).toContainEqual(expectedAction);
+    done();
+  });
+
+  it('dispatches SIGNUP_USER_SOCIAL on social login/signup', async done => {
+    const res = {
+      email: 'kathiekim95@gmail.com',
+      username: 'kathiekim',
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJ1c2VybmFtZSI6ImthdGhpZWtpbTk1QGdtYWlsLmNvbSIsImV4cCI6MTU1OTg2MDM1NywiZW1haWwiOiJrYXRoaWVraW05NUBnbWFpbC5jb20ifQ.taJlapQocvE86WnZNyJhTKwgkzN_ldl4dgM05MWPkkw',
+    };
+
+    const expectedAction = socialAction(res);
+    moxios.stubRequest(`${BASE_URL}/users/social/login`, { status: 200, response: res });
+    await store.dispatch(socialAction(res));
     expect(store.getActions()).toContainEqual(expectedAction);
     done();
   });

--- a/tests/SignUpView.test.js
+++ b/tests/SignUpView.test.js
@@ -6,6 +6,10 @@ import { Provider } from 'react-redux';
 import store from '../src/redux/store/';
 
 describe('unit tests for sign up view', () => {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  document.getElementsByTagName('head')[0].appendChild(script);
+
   const props = {
     onSubmit: jest.fn(),
     onChange: jest.fn(),

--- a/tests/Social.test.js
+++ b/tests/Social.test.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import FacebookLogin from 'react-facebook-login';
+import configureMockStore from 'redux-mock-store';
+import store from '../src/redux/store';
+import SocialLogin from '../src/components/auth/Social';
+
+/*
+ *This function mounts the
+ *component to test
+ */
+const setUp = (props = {}) => {
+  const component = mount(
+    <BrowserRouter>
+      <Provider store={store}>
+        <SocialLogin {...props} />
+      </Provider>
+    </BrowserRouter>,
+  );
+  return component;
+};
+
+/*
+ *This function finds a component
+ *by its data-set attribute
+ */
+const findByAttribute = (component, attr) => {
+  const wrapper = component.find(`[data-set='${attr}']`);
+  return wrapper;
+};
+
+const mockStore = configureMockStore();
+const store1 = mockStore({});
+
+describe('Unit tests for SocialLogin component', () => {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  document.getElementsByTagName('head')[0].appendChild(script);
+
+  let component;
+  beforeEach(() => {
+    component = setUp();
+  });
+
+  it('Should render the SocialLoginDiv', () => {
+    const wrapper = findByAttribute(component, 'SocialLoginDiv');
+    expect(wrapper.exists()).toBe(true);
+  });
+});
+
+describe('component changes state', () => {
+  const expectedState = { isClicked: true };
+  const newWrapper = shallow(
+    <BrowserRouter>
+      <Provider store={store}>
+        <SocialLogin />
+      </Provider>
+    </BrowserRouter>,
+  );
+  newWrapper.setState({ isClicked: true });
+  newWrapper.update();
+
+  it('should update the state', () => {
+    expect(newWrapper.state()).toEqual(expectedState);
+  });
+});
+
+describe('unit tests for clicking social buttons', () => {
+  const mockComponentClickedFn = jest.fn();
+  const onClickMock = jest.fn(() => {
+    mockComponentClickedFn();
+  });
+
+  const props = {
+    UserSocialLogin: jest.fn(),
+  };
+
+  const wrapper = shallow(
+    <BrowserRouter>
+      <Provider store={store1}>
+        <SocialLogin store={store1}>
+          <FacebookLogin onClick={onClickMock} />
+        </SocialLogin>
+      </Provider>
+    </BrowserRouter>,
+  );
+
+  const wrapmount = mount(
+    <BrowserRouter>
+      <Provider store={store1}>
+        <SocialLogin store={store1} {...props} />
+      </Provider>
+    </BrowserRouter>,
+  );
+
+  const tree = wrapper
+    .find(SocialLogin)
+    .shallow()
+    .find(FacebookLogin)
+    .shallow();
+
+  it('should render', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should call method', () => {
+    const component = shallow(<FacebookLogin />);
+    expect(component.exists()).toEqual(true);
+    console.log(tree.props());
+    tree.simulate('click');
+    expect(mockComponentClickedFn).toBeCalled();
+  });
+
+  it('test james', () => {
+    const facebookbutton = wrapmount.find('button[id="facebookLogin"]');
+    const googlebutton = wrapmount.find('button[id="googleLogin"]');
+    facebookbutton.simulate('click');
+    googlebutton.simulate('click');
+    expect(googlebutton.length).toEqual(1);
+    expect(facebookbutton.length).toEqual(1);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Implements social login

### Description of Task(s) to be completed?
- implement functionality to get access token from facebook/ google
- include social media icons on both signup and sign in pages
- send login request to ah backend using access token and provider details
- show spinner when logging in
- disable buttons after response
- update failing tests
- add tests for social login

### How should this be manually tested?

Clone this repository on local machine and CD into project folder
`$ git clone git@github.com:andela/ah-the-jedi-frontend.git`
`$ cd ah-the-jedi-frontend`

Check out to the PR's branch
`$ git checkout ft-social-login-165305224`

install dependencies and run the dev server
`npm install`
`npm run start:dev`

navigate to login and signup page and interact with social login buttons

### What are the relevant PT stories?
[#165305224](https://www.pivotaltracker.com/story/show/165305224)

### Screenshots
![image](https://user-images.githubusercontent.com/11965186/59035100-3435c100-8875-11e9-85cb-bddd3e6b529d.png)

![image](https://user-images.githubusercontent.com/11965186/59035172-5c252480-8875-11e9-9d09-76a66355c549.png)
